### PR TITLE
Delete wrong trailing symbols in link of SR66.md

### DIFF
--- a/Surveillance Report Sources/SR66.md
+++ b/Surveillance Report Sources/SR66.md
@@ -78,4 +78,4 @@ https://safing.io/blog/2021/12/06/spn-reaches-alpha/
 
 # Misfits
 
-https://www.bleepingcomputer.com/news/security/phishing-attacks-use-qr-codes-to-steal-banking-credentials/​​​​​​​
+https://www.bleepingcomputer.com/news/security/phishing-attacks-use-qr-codes-to-steal-banking-credentials/


### PR DESCRIPTION
I deleted these incorrect & trailing symbols (appears to be circular bullet symbols?) so that the very last hyperlink (to Bleeping Computer) will work.
Otherwise, the link as it is will point to a 404 not found page on Bleeping Computer.