### PR TITLE
Replace link to Community with Link to Space in community-rules.md

### DIFF
--- a/community-rules.md
+++ b/community-rules.md
@@ -3,7 +3,7 @@
 
 We host two major communities to offer a place for people to chat about privacy and learn from other community members. We believe in offering a tier-based system: from non-privacy services to heavily-privacy-respecting to cater to all possible audiences and give them a place to chat about privacy. We've bridged both communities so they can directly communicate with each other. Even if they decide not to switch, we are aware of varying threat models and are happy to accomodate community memebrs of all levels.
  * [Discord](https://discord.gg/74WhF9C)
- * [Matrix](https://matrix.to/#/+techlore-official:matrix.org)
+ * [Matrix](https://matrix.to/#/#techlore:techlore.net)
  
  
 ## Rules

--- a/community-rules.md
+++ b/community-rules.md
@@ -3,7 +3,7 @@
 
 We host two major communities to offer a place for people to chat about privacy and learn from other community members. We believe in offering a tier-based system: from non-privacy services to heavily-privacy-respecting to cater to all possible audiences and give them a place to chat about privacy. We've bridged both communities so they can directly communicate with each other. Even if they decide not to switch, we are aware of varying threat models and are happy to accomodate community memebrs of all levels.
  * [Discord](https://discord.gg/74WhF9C)
- * [Matrix](https://matrix.to/#/#techlore:techlore.net)
+ * [Matrix](https://matrix.to/#/#techlore:matrix.org)
  
  
 ## Rules


### PR DESCRIPTION
Updated community-rules.md to replace the link to the previous group(community is the name in element) to be a link to the space.