### PR TITLE
Updated our current affiliates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,9 @@ We've been previously opposed to sponsors, but after asking our community for th
 
 
 ## Affiliates
-Affiliate marketing is our largest source of revenue. 
-
 Affiliate marketing has a bad rep and for good reason--they're frequently abused with little transparancy behind their usage. However, affiliate marketing offers the utmost creative freedom to individuals without relying on a traditional sponsorship relationship where conflicts of interest may arise.
 
-As individuals, we crave the creative freedom to select and drop our sources of income at will; we created [this document](https://github.com/techlore/YT-channel/blob/master/affiliates.md) explaining how we prevent conflicts of interest and maintain transparancy behind what we recommend to our audience. We will not allow our content or recommendations to be influenced by an affiliate plan.
+As individuals, we crave the creative freedom to select and drop our sources of income at will; we created [this document](https://github.com/techlore/channel-content/blob/master/affiliates.md) explaining how we prevent conflicts of interest and maintain transparancy behind what we recommend to our audience. We will not allow our content or recommendations to be influenced by an affiliate plan.
 
 ## Assets
 You'll find some of our [assets](https://github.com/techlore/channel-content/tree/master/Assets) in this repo. You are not allowed to steal our assets, but if you're covering our work and would like to reference us go for it. 

--- a/affiliates.md
+++ b/affiliates.md
@@ -22,14 +22,14 @@ If we answer these questions and feel a service is not only a positive experienc
 ## Our Current Affiliates
 Here are our current affiliate plans. Some have rarely (or ever) been mentioned in our content. This is due to us not finding a right fit for the service, as we try to keep recommendations relevant to the content. We don't want to recommend shaving cream to our audience.
 
-- [Amazon](https://www.amazon.com/shop/influencer20170928875)
 - [Brave Rewards](https://brave.com/tec118)
 - [ProtonMail](https://proton.go2cloud.org/SHAo)
 - [SimpleLogin](https://simplelogin.io/?slref=techlore)
 - [Orange Website](https://affiliate.orangewebsite.com/idevaffiliate.php?id=10799)
-- [Trezor Wallet](https://shop.trezor.io/?offer_id=10&aff_id=5536)
 - [Jumbo Privacy](https://web.jumboprivacy.com/?utm_source=youtube&utm_campaign=techlore)
 - [Abine DeleteMe](https://www.anrdoezrs.net/click-100370169-13794293)
+
+(Updated April 8th, 2022)
 
 ***Links above are the affiliate links themselves.***
 


### PR DESCRIPTION
Readme Updates:
- Updated the affiliate link to the correct URL
- Removed affiliates being our largest source of revenue, which is technically still true - but likely to change in the near future during our migration to sponsors

Affiliate Updates:
- We have removed Amazon for some time now, this is to reflect the change. The old link is still accessible as we finish removing the account, but the link has been removed on all videos & our website (That we're aware of! Please let us know if you find one we missed, it's hard to catch them all)
- Trezor has been removed as well as it was recently removed from our resources.